### PR TITLE
chore: format source

### DIFF
--- a/ControlFlowGraphs/lang.py
+++ b/ControlFlowGraphs/lang.py
@@ -17,6 +17,7 @@ Python 3. It will not work with standard Python 2.
 from collections import deque
 from abc import ABC, abstractclassmethod
 
+
 class Env:
     """
     A table that associates variables with values. The environment is
@@ -35,6 +36,7 @@ class Env:
         >>> e.get("a") + e.get("b")
         7
     """
+
     def __init__(s, initial_args={}):
         s.env = deque()
         for var, value in initial_args.items():
@@ -63,7 +65,7 @@ class Env:
         Prints the contents of the environment. This method is mostly used for
         debugging purposes.
         """
-        for (var, value) in s.env:
+        for var, value in s.env:
             print(f"{var}: {value}")
 
 
@@ -74,6 +76,7 @@ class Inst(ABC):
     attribute determines the next instruction that will be fetched after this
     instruction runs.
     """
+
     def __init__(self):
         self.NEXTS = []
         self.index = 0
@@ -102,6 +105,7 @@ class BinOp(Inst):
     value, and use two values. As such, it contains a routine to extract the
     defined value, and the list of used values.
     """
+
     def __init__(s, dst, src0, src1):
         s.dst = dst
         s.src0 = src0
@@ -128,6 +132,7 @@ class Add(BinOp):
         >>> a.get_next() == None
         True
     """
+
     def eval(s, env):
         env.set(s.dst, env.get(s.src0) + env.get(s.src1))
 
@@ -141,6 +146,7 @@ class Mul(BinOp):
         >>> e.get("a")
         6
     """
+
     def eval(s, env):
         env.set(s.dst, env.get(s.src0) * env.get(s.src1))
 
@@ -154,6 +160,7 @@ class Lth(BinOp):
         >>> e.get("a")
         True
     """
+
     def eval(s, env):
         env.set(s.dst, env.get(s.src0) < env.get(s.src1))
 
@@ -167,6 +174,7 @@ class Geq(BinOp):
         >>> e.get("a")
         False
     """
+
     def eval(s, env):
         env.set(s.dst, env.get(s.src0) >= env.get(s.src1))
 
@@ -186,6 +194,7 @@ class Bt(Inst):
         >>> b.get_next() == a
         True
     """
+
     def __init__(s, cond, true_dst=None, false_dst=None):
         super().__init__()
         s.cond = cond
@@ -214,6 +223,7 @@ class Bt(Inst):
 
     def get_next(s):
         return s.NEXTS[s.next_iter]
+
 
 def interp(instruction, environment):
     """

--- a/ControlFlowGraphs/lang.py
+++ b/ControlFlowGraphs/lang.py
@@ -15,7 +15,7 @@ Python 3. It will not work with standard Python 2.
 """
 
 from collections import deque
-from abc import ABC, abstractclassmethod
+from abc import ABC, abstractmethod
 
 
 class Env:
@@ -84,11 +84,13 @@ class Inst(ABC):
     def add_next(self, next_inst):
         self.NEXTS.append(next_inst)
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def definition(self):
         raise NotImplementedError
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def uses(self):
         raise NotImplementedError
 

--- a/ControlFlowGraphs/todo.py
+++ b/ControlFlowGraphs/todo.py
@@ -1,5 +1,6 @@
 from lang import *
 
+
 def test_min(m, n):
     """
     Stores in the variable 'answer' the minimum of 'm' and 'n'
@@ -18,6 +19,7 @@ def test_min(m, n):
     p.add_next(b)
     interp(p, env)
     return env.get("answer")
+
 
 def test_fib(n):
     """
@@ -47,6 +49,7 @@ def test_fib(n):
     interp(i0, env)
     return env.get("answer")
 
+
 def test_min3(x, y, z):
     """
     Stores in the variable 'answer' the minimum of 'x', 'y' and 'z'
@@ -59,6 +62,7 @@ def test_min3(x, y, z):
     """
     # TODO: Implement this method
     return env.get("answer")
+
 
 def test_div(m, n):
     """
@@ -74,6 +78,7 @@ def test_div(m, n):
     """
     # TODO: Implement this method
     return env.get("answer")
+
 
 def test_fact(n):
     """

--- a/IntroDataFlow/dataflow.py
+++ b/IntroDataFlow/dataflow.py
@@ -1,6 +1,7 @@
 from lang import *
 from abc import ABC, abstractclassmethod
 
+
 class DataFlowEq(ABC):
     """
     A class that implements a data-flow equation. The key trait of a data-flow
@@ -8,13 +9,14 @@ class DataFlowEq(ABC):
     of an equation might change the environment that associates data-flow facts
     with identifiers.
     """
+
     def __init__(self, instruction):
         """
         Every data-flow equation is produced out of a program instruction. The
         initialization of the data-flow equation verifies if, indeed, the input
         object is an instruction.
         """
-        assert(isinstance(instruction, Inst))
+        assert isinstance(instruction, Inst)
         self.inst = instruction
 
     @abstractclassmethod
@@ -54,6 +56,7 @@ class DataFlowEq(ABC):
         data_flow_env[self.name()] = self.eval_aux(data_flow_env)
         return True if data_flow_env[self.name()] != old_env else False
 
+
 def name_in(ID):
     """
     The name of an IN set is always ID + _IN. Eg.:
@@ -64,13 +67,16 @@ def name_in(ID):
     """
     return f"IN_{ID}"
 
+
 class IN_Eq(DataFlowEq):
     """
     This abstract class represents all the equations that affect the IN set
     related to some program point.
     """
+
     def name(self):
         return name_in(self.inst.ID)
+
 
 def name_out(ID):
     """
@@ -82,13 +88,16 @@ def name_out(ID):
     """
     return f"OUT_{ID}"
 
+
 class OUT_Eq(DataFlowEq):
     """
     This abstract class represents all the equations that affect the OUT set
     related to some program point.
     """
+
     def name(self):
         return name_out(self.inst.ID)
+
 
 class ReachingDefs_Bin_OUT_Eq(OUT_Eq):
     """
@@ -97,6 +106,7 @@ class ReachingDefs_Bin_OUT_Eq(OUT_Eq):
     have three fields: dst, src0 and src1; however, only the former is of
     interest for these equations.
     """
+
     def eval_aux(self, data_flow_env):
         """
         Evaluates this equation, where:
@@ -127,6 +137,7 @@ class ReachingDefs_Bin_OUT_Eq(OUT_Eq):
         gen_set = f"({self.inst.dst}, {self.inst.ID})"
         return f"{self.name()}: {gen_set}{kill_set}"
 
+
 class ReachingDefs_Bt_OUT_Eq(OUT_Eq):
     """
     This concrete class implements the equations that affect OUT facts of the
@@ -134,6 +145,7 @@ class ReachingDefs_Bt_OUT_Eq(OUT_Eq):
     do not affect reaching definitions at all. Therefore, their equations are
     mostly treated as identity functions.
     """
+
     def eval_aux(self, data_flow_env):
         """
         Evaluates this equation. Notice that the reaching definition equation
@@ -163,12 +175,14 @@ class ReachingDefs_Bt_OUT_Eq(OUT_Eq):
         gen_set = f""
         return f"{self.name()}: {gen_set}{kill_set}"
 
+
 class ReachingDefs_IN_Eq(IN_Eq):
     """
     This concrete class implements the meet operation for reaching-definition
     analysis. The meet operation produces the IN set of a program point. This
     IN set is the union of the OUT set of the predecessors of this point.
     """
+
     def eval_aux(self, data_flow_env):
         """
         The evaluation of the meet operation over reaching definitions is the
@@ -205,8 +219,9 @@ class ReachingDefs_IN_Eq(IN_Eq):
             >>> str(df)
             'IN_2: Union( OUT_0, OUT_1 )'
         """
-        succs = ', '.join([name_out(pred.ID) for pred in self.inst.preds])
+        succs = ", ".join([name_out(pred.ID) for pred in self.inst.preds])
         return f"{self.name()}: Union( {succs} )"
+
 
 class LivenessAnalysisIN_Eq(IN_Eq):
     def eval_aux(self, data_flow_env):
@@ -239,6 +254,7 @@ class LivenessAnalysisIN_Eq(IN_Eq):
         """
         kill_set = f"({name_out(self.inst.ID)} - {self.inst.definition()})"
         return f"{self.name()}: {kill_set} + {sorted(self.inst.uses())}"
+
 
 class LivenessAnalysisOUT_Eq(OUT_Eq):
     def eval_aux(self, data_flow_env):
@@ -276,6 +292,7 @@ class LivenessAnalysisOUT_Eq(OUT_Eq):
             succs += name_in(inst.ID)
         return f"{self.name()}: Union( {succs} )"
 
+
 def reaching_defs_constraint_gen(insts):
     """
     Builds a list of equations to solve Reaching-Definition Analysis for the
@@ -298,6 +315,7 @@ def reaching_defs_constraint_gen(insts):
     out = [ReachingDefs_IN_Eq(i) for i in insts]
     return in0 + in1 + out
 
+
 def liveness_constraint_gen(insts):
     """
     Builds a list of liness-analysis equations extracted from the instructions
@@ -315,6 +333,7 @@ def liveness_constraint_gen(insts):
     """
     # TODO: implement this method.
     return None
+
 
 def abstract_interp(equations):
     """
@@ -343,6 +362,7 @@ def abstract_interp(equations):
         "IN_0: [], OUT_0: [('c', 0)]"
     """
     from functools import reduce
+
     env = {eq.name(): set() for eq in equations}
     changed = True
     while changed:

--- a/IntroDataFlow/dataflow.py
+++ b/IntroDataFlow/dataflow.py
@@ -1,5 +1,5 @@
 from lang import *
-from abc import ABC, abstractclassmethod
+from abc import ABC, abstractmethod
 
 
 class DataFlowEq(ABC):
@@ -19,7 +19,8 @@ class DataFlowEq(ABC):
         assert isinstance(instruction, Inst)
         self.inst = instruction
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def name(self) -> str:
         """
         The name of a data-flow equation is used to retrieve the data-flow
@@ -34,7 +35,8 @@ class DataFlowEq(ABC):
         """
         raise NotImplementedError
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def eval_aux(self, data_flow_env) -> set:
         """
         This method determines how each concrete equation evaluates itself.

--- a/IntroDataFlow/driver.py
+++ b/IntroDataFlow/driver.py
@@ -5,6 +5,7 @@ import dataflow
 
 from lang import interp
 
+
 def check_environment(env, init_in):
     """
     This function is an example of how liveness analysis can be used.
@@ -27,9 +28,11 @@ def check_environment(env, init_in):
         except LookupError:
             print(f"{var} is used without being defined")
 
+
 def print_instructions(instructions):
     for inst in instructions:
         print(inst)
+
 
 if __name__ == "__main__":
     """

--- a/IntroDataFlow/lang.py
+++ b/IntroDataFlow/lang.py
@@ -15,7 +15,7 @@ Python 3. It will not work with standard Python 2.
 """
 
 from collections import deque
-from abc import ABC, abstractclassmethod
+from abc import ABC, abstractmethod
 
 
 class Env:
@@ -90,11 +90,13 @@ class Inst(ABC):
         self.nexts.append(next_inst)
         next_inst.preds.append(self)
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def definition(self):
         raise NotImplementedError
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def uses(self):
         raise NotImplementedError
 
@@ -118,7 +120,8 @@ class BinOp(Inst):
         s.src1 = src1
         super().__init__()
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def get_opcode(self):
         raise NotImplementedError
 

--- a/IntroDataFlow/lang.py
+++ b/IntroDataFlow/lang.py
@@ -17,6 +17,7 @@ Python 3. It will not work with standard Python 2.
 from collections import deque
 from abc import ABC, abstractclassmethod
 
+
 class Env:
     """
     A table that associates variables with values. The environment is
@@ -35,6 +36,7 @@ class Env:
         >>> e.get("a") + e.get("b")
         7
     """
+
     def __init__(s, initial_args={}):
         s.env = deque()
         for var, value in initial_args.items():
@@ -63,7 +65,7 @@ class Env:
         Prints the contents of the environment. This method is mostly used for
         debugging purposes.
         """
-        for (var, value) in s.env:
+        for var, value in s.env:
             print(f"{var}: {value}")
 
 
@@ -75,6 +77,7 @@ class Inst(ABC):
     instruction runs. Also, every instruction has an index, which is always
     different. The index is incremented whenever a new instruction is created.
     """
+
     next_index = 0
 
     def __init__(self):
@@ -108,6 +111,7 @@ class BinOp(Inst):
     value, and use two values. As such, it contains a routine to extract the
     defined value, and the list of used values.
     """
+
     def __init__(s, dst, src0, src1):
         s.dst = dst
         s.src0 = src0
@@ -145,11 +149,12 @@ class Add(BinOp):
         >>> a.get_next() == None
         True
     """
+
     def eval(self, env):
         env.set(self.dst, env.get(self.src0) + env.get(self.src1))
 
     def get_opcode(self):
-        return '+'
+        return "+"
 
 
 class Mul(BinOp):
@@ -161,11 +166,12 @@ class Mul(BinOp):
         >>> e.get("a")
         6
     """
+
     def eval(s, env):
         env.set(s.dst, env.get(s.src0) * env.get(s.src1))
 
     def get_opcode(self):
-        return '*'
+        return "*"
 
 
 class Lth(BinOp):
@@ -177,11 +183,12 @@ class Lth(BinOp):
         >>> e.get("a")
         True
     """
+
     def eval(s, env):
         env.set(s.dst, env.get(s.src0) < env.get(s.src1))
 
     def get_opcode(self):
-        return '<'
+        return "<"
 
 
 class Geq(BinOp):
@@ -193,11 +200,12 @@ class Geq(BinOp):
         >>> e.get("a")
         False
     """
+
     def eval(s, env):
         env.set(s.dst, env.get(s.src0) >= env.get(s.src1))
 
     def get_opcode(self):
-        return '>='
+        return ">="
 
 
 class Bt(Inst):
@@ -215,6 +223,7 @@ class Bt(Inst):
         >>> b.get_next() == a
         True
     """
+
     def __init__(s, cond, true_dst=None, false_dst=None):
         super().__init__()
         s.cond = cond

--- a/IntroDataFlow/parser.py
+++ b/IntroDataFlow/parser.py
@@ -6,6 +6,7 @@ integer values.
 
 from lang import *
 
+
 def line2env(line):
     """
     Maps a string (the line) to a dictionary in python. This function will be
@@ -18,11 +19,13 @@ def line2env(line):
         1
     """
     import json
+
     env_dict = json.loads(line)
     env_lang = Env()
     for k, v in env_dict.items():
         env_lang.set(k, v)
     return env_lang
+
 
 def file2cfg_and_env(lines):
     """

--- a/Parsing/lang.py
+++ b/Parsing/lang.py
@@ -17,6 +17,7 @@ Python 3. It will not work with standard Python 2.
 from collections import deque
 from abc import ABC, abstractclassmethod
 
+
 class Env:
     """
     A table that associates variables with values. The environment is
@@ -35,6 +36,7 @@ class Env:
         >>> e.get("a") + e.get("b")
         7
     """
+
     def __init__(s, initial_args={}):
         s.env = deque()
         for var, value in initial_args.items():
@@ -63,7 +65,7 @@ class Env:
         Prints the contents of the environment. This method is mostly used for
         debugging purposes.
         """
-        for (var, value) in s.env:
+        for var, value in s.env:
             print(f"{var}: {value}")
 
 
@@ -74,6 +76,7 @@ class Inst(ABC):
     attribute determines the next instruction that will be fetched after this
     instruction runs.
     """
+
     def __init__(self):
         self.NEXTS = []
         self.index = 0
@@ -102,6 +105,7 @@ class BinOp(Inst):
     value, and use two values. As such, it contains a routine to extract the
     defined value, and the list of used values.
     """
+
     def __init__(s, dst, src0, src1):
         s.dst = dst
         s.src0 = src0
@@ -128,6 +132,7 @@ class Add(BinOp):
         >>> a.get_next() == None
         True
     """
+
     def eval(s, env):
         env.set(s.dst, env.get(s.src0) + env.get(s.src1))
 
@@ -141,6 +146,7 @@ class Mul(BinOp):
         >>> e.get("a")
         6
     """
+
     def eval(s, env):
         env.set(s.dst, env.get(s.src0) * env.get(s.src1))
 
@@ -154,6 +160,7 @@ class Lth(BinOp):
         >>> e.get("a")
         True
     """
+
     def eval(s, env):
         env.set(s.dst, env.get(s.src0) < env.get(s.src1))
 
@@ -167,6 +174,7 @@ class Geq(BinOp):
         >>> e.get("a")
         False
     """
+
     def eval(s, env):
         env.set(s.dst, env.get(s.src0) >= env.get(s.src1))
 
@@ -186,6 +194,7 @@ class Bt(Inst):
         >>> b.get_next() == a
         True
     """
+
     def __init__(s, cond, true_dst=None, false_dst=None):
         super().__init__()
         s.cond = cond
@@ -214,6 +223,7 @@ class Bt(Inst):
 
     def get_next(s):
         return s.NEXTS[s.next_iter]
+
 
 def interp(instruction, environment):
     """

--- a/Parsing/lang.py
+++ b/Parsing/lang.py
@@ -15,7 +15,7 @@ Python 3. It will not work with standard Python 2.
 """
 
 from collections import deque
-from abc import ABC, abstractclassmethod
+from abc import ABC, abstractmethod
 
 
 class Env:
@@ -84,11 +84,13 @@ class Inst(ABC):
     def add_next(self, next_inst):
         self.NEXTS.append(next_inst)
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def definition(self):
         raise NotImplementedError
 
-    @abstractclassmethod
+    @classmethod
+    @abstractmethod
     def uses(self):
         raise NotImplementedError
 

--- a/Parsing/todo.py
+++ b/Parsing/todo.py
@@ -15,6 +15,7 @@ As an example, the program below sums up the numbers a, b and c:
 
 from lang import *
 
+
 def line2env(line):
     """
     Maps a string (the line) to a dictionary in python. This function will be
@@ -27,11 +28,13 @@ def line2env(line):
         1
     """
     import json
+
     env_dict = json.loads(line)
     env_lang = Env()
     for k, v in env_dict.items():
         env_lang.set(k, v)
     return env_lang
+
 
 def file2cfg_and_env(lines):
     """


### PR DESCRIPTION
This PR formats the source with [black](https://pypi.org/project/black/), an automatic Python code formatter. I've also replaced the `abstractclassmethod` decorator with a pair of `abstractmethod`/`classmethod` as it was deprecated in Python 3.3 ([source](https://docs.python.org/3/library/abc.html#abc.abstractclassmethod)).