### PR TITLE
Define eval as abstractmethod on Inst, making BinOp an ABC

### DIFF
--- a/ControlFlowGraphs/lang.py
+++ b/ControlFlowGraphs/lang.py
@@ -84,6 +84,14 @@ class Inst(ABC):
     def add_next(self, next_inst):
         self.NEXTS.append(next_inst)
 
+    @abstractmethod
+    def eval(s, env):
+        """
+        Derived classes that don't implement this method will also be abstract,
+        such as BinOp
+        """
+        pass
+
     @classmethod
     @abstractmethod
     def definition(self):


### PR DESCRIPTION
By defining `eval` as an `@abstractmethod` on `Inst`, it's possible to create derived abstract classes of `Inst` (which is what I think was intended for `BinOP`, as without the change it's possible to instantiate a generic BinOp).

I copied the doctest example from `class Add` in a separate file, including an instantiation of a `BinOp`:
```
# ControlFlowGraphs/test_BinOp.py

def toast():
    """
    Example:
        >>> a = Add("a", "b0", "b1")
        >>> op = BinOp("a", "b0", "b1")
        >>> e = Env({"b0":2, "b1":3})
        >>> a.eval(e)
        >>> e.get("a")
        5

        >>> a = Add("a", "b0", "b1")
        >>> a.get_next() == None
        True
    """
    pass

```

Without the change:
```
(.venv) : [0] condekind@seath:/home/condekind/repos/DCC888 ; python -m doctest ControlFlowGraphs/test_BinOp.py; if [[ $? -eq 0 ]]; then { printf "Success\n"; }; fi
Success

```

With the change:
```
(.venv) : [0] condekind@seath:/home/condekind/repos/DCC888 ; python -m doctest ControlFlowGraphs/test_BinOp.py; if [[ $? -eq 0 ]]; then { printf "Success\n"; }; fi
**********************************************************************
File "/home/condekind/repos/DCC888/ControlFlowGraphs/test_BinOp.py", line 8, in test_BinOp.toast
Failed example:
    op = BinOp("a", "b0", "b1")
Exception raised:
    Traceback (most recent call last):
      File "/home/condekind/.local/share/pyenv/versions/3.9.18/lib/python3.9/doctest.py", line 1334, in __run
        exec(compile(example.source, filename, "single",
      File "<doctest test_BinOp.toast[1]>", line 1, in <module>
        op = BinOp("a", "b0", "b1")
    TypeError: Can't instantiate abstract class BinOp with abstract method eval
**********************************************************************
1 items had failures:
   1 of   7 in test_BinOp.toast
***Test Failed*** 1 failures.
```