### PR TITLE
Register allocation through coloring of Chordal graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,7 @@ In this [lab](/AliasAnalysis), the student will implement a version of Andersen-
 ### Type Checking
 
 In this [lab](/TypeChecking), the student will implement Type-Checking to verify if programs are **Safe**, as seen in [class](https://homepages.dcc.ufmg.br/~fernando/classes/dcc888/ementa/slides/TypeSystems.pdf)
+
+### Register Allocation by coloring chordal graphs
+
+In this [lab](/SSARegisterAllocation), the student will build and color the interference graph of programs in SSA-form using maximum cardinality search and greedy coloring. The resulting coloring represents the minimum register allocation without spilling, as seen in [SSA-Based Register Allocation](https://homepages.dcc.ufmg.br/~fernando/classes/dcc888/ementa/slides/SSABasedRA.pdf)

--- a/SSARegisterAllocation/README.md
+++ b/SSARegisterAllocation/README.md
@@ -1,0 +1,41 @@
+# Register allocation by coloring chordal graphs
+This exercise is based on part of the paper [Register Allocation via Coloring of Chordal Graphs](https://homepages.dcc.ufmg.br/~fernando/publications/papers/APLAS05.pdf). Although programs may introduce an arbitrary number of variables, all software runs on an underlying CPU with a limited number of registers. This comes forth the problem of **register allocation**: given the limited amount of registers available, changing the program in order to reduce its register demand is quite useful. Figuring out how many registers are necessary for all variables in the current program is one step of solving this problem.
+
+Variables that are simultaneously alive require concurrent registers. It is useful to build an interference graph that represents each variable as a vertex, while edges connect variables that share live time in the program:
+
+![Interference graph](../assets/images/interferencegraph.png)
+
+
+Register assignment can be represented by coloring a vertex, thus turning the problem into an instance of graph-coloring. While discovering the chromatic number of a general graph is NP-complete, the minimum coloring of chordal (triangular) graphs can be found in linear time. 
+
+A graph is chordal if it has no induced subgraph isomorphic to CN, N>3. Fortunately, [SSA-form programs have chordal interference graphs](https://compilers.cs.uni-saarland.de/papers/ifg_ssa.pdf).
+
+![Chordal graph](../assets/images/chordalgraph.png)
+
+(a) and (d) are chordal graphs. (c) Is isomorphic to C4, and so is the induced subgraph of (b) containing only its corners.
+
+## The Assignment
+This lab consists in implementing the algorithm for finding the chromatic number (the minimum amount of required registers) for programs in SSA-form. By the end we will be able not only to know how many registers are required, but obtain a sample coloring (note that the exact colorings may vary on each iteration). In order to do so, the incomplete class `InterferenceGraph` is presented. This class builds the interference graph of a program, and it must contain all the logic for register allocation. Students must implement the methods `maximum_cardinality_search` and `greedy_coloring` , the two main algorithms involved in coloring chordal graphs.
+
+
+Besides the `driver.py` and `lang.py` modules, the following files are required:
+- A [liveness analysis](../IntroDataFlow) implementation.
+- [phi functions](../PhiFunctions) should be fully implemented.
+
+Note also that `lang.py` has been slightly modified to allow numbers to be used directly in programs. **Do not overwrite it, complete the missing parts instead**.This removes the need to define all numbers as environment variables, hence reducing overlapping variables and simplifying register allocation. The parser has been purposefully omitted from this exercise as to avoid the need to adapt it to numerals as well - all programs are instantiated in python.
+
+
+## Uploading the Assignment
+
+Students enrolled in DCC888 have access to UFMG's grading system, via [Moodle](https://moodle.org/).
+You must upload four python files to have your assignment graded: [driver.py](driver.py), [lang.py](lang.py), [dataflow.py](dataflow.py) and [graph.py](graph.ph)
+Remember to click on "*Avaliar*" to have your assignment graded.
+
+## Testing without Moodle
+
+As in the previous labs, all the files in this exercise contain `doctest` comments.
+You can easily test your implementation by doing, for instance:
+
+```
+python3 -m doctest lang.py
+```

--- a/SSARegisterAllocation/dataflow.py
+++ b/SSARegisterAllocation/dataflow.py
@@ -1,0 +1,370 @@
+from lang import Inst, BinOp, Bt
+from abc import ABC, abstractmethod
+
+
+class DataFlowEq(ABC):
+    """
+    A class that implements a data-flow equation. The key trait of a data-flow
+    equation is an `eval` method, which evaluates that equation. The evaluation
+    of an equation might change the environment that associates data-flow facts
+    with identifiers.
+    """
+
+    def __init__(self, instruction):
+        """
+        Every data-flow equation is produced out of a program instruction. The
+        initialization of the data-flow equation verifies if, indeed, the input
+        object is an instruction.
+        """
+        assert isinstance(instruction, Inst)
+        self.inst = instruction
+
+    @classmethod
+    @abstractmethod
+    def name(self) -> str:
+        """
+        The name of a data-flow equation is used to retrieve the data-flow
+        facts associated with that equation in the environment. For instance,
+        imagine that we have an equation like this one below:
+
+        "OUT[p] = (v, p) + (IN[p] - (v, _))"
+
+        This equation affects OUT[p]. We store OUT[p] in a dictionary. The name
+        of the equation is used as the key in this dictionary. For instance,
+        the name of the equation could be 'OUT_p'.
+        """
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def eval_aux(self, data_flow_env) -> set:
+        """
+        This method determines how each concrete equation evaluates itself.
+        In a way, this design implements the 'template method' pattern. In other
+        words, the DataFlowEq class implements a concrete method eval, which
+        calls the abstract method eval_aux. It is the concrete implementation of
+        eval_aux that determines how the environment is affected by the
+        evaluation of a given equation.
+        """
+        raise NotImplementedError
+
+    def eval(self, data_flow_env) -> bool:
+        """
+        This method implements the abstract evaluation of a data-flow equation.
+        Notice that the actual semantics of this evaluation will be implemented
+        by the `èval_aux` method, which is abstract.
+        """
+        old_env = data_flow_env[self.name()]
+        data_flow_env[self.name()] = self.eval_aux(data_flow_env)
+        return True if data_flow_env[self.name()] != old_env else False
+
+
+def name_in(ID):
+    """
+    The name of an IN set is always ID + _IN. Eg.:
+        >>> Inst.next_index = 0
+        >>> add = Add('x', 'a', 'b')
+        >>> name_in(add.ID)
+        'IN_0'
+    """
+    return f"IN_{ID}"
+
+
+class IN_Eq(DataFlowEq):
+    """
+    This abstract class represents all the equations that affect the IN set
+    related to some program point.
+    """
+
+    def name(self):
+        return name_in(self.inst.ID)
+
+
+def name_out(ID):
+    """
+    The name of an OUT set is always ID + _OUT. Eg.:
+        >>> Inst.next_index = 0
+        >>> add = Add('x', 'a', 'b')
+        >>> name_out(add.ID)
+        'OUT_0'
+    """
+    return f"OUT_{ID}"
+
+
+class OUT_Eq(DataFlowEq):
+    """
+    This abstract class represents all the equations that affect the OUT set
+    related to some program point.
+    """
+
+    def name(self):
+        return name_out(self.inst.ID)
+
+
+class ReachingDefs_Bin_OUT_Eq(OUT_Eq):
+    """
+    This concrete class implements the equations that affect OUT facts of the
+    reaching-definitions analysis for binary instructions. These instructions
+    have three fields: dst, src0 and src1; however, only the former is of
+    interest for these equations.
+    """
+
+    def eval_aux(self, data_flow_env):
+        """
+        Evaluates this equation, where:
+        OUT[p] = (v, p) + (IN[p] - (v, _))
+
+        Example:
+            >>> Inst.next_index = 0
+            >>> i0 = Add('x', 'a', 'b')
+            >>> df = ReachingDefs_Bin_OUT_Eq(i0)
+            >>> sorted(df.eval_aux({'IN_0': {('x', 1), ('y', 2)}}))
+            [('x', 0), ('y', 2)]
+        """
+        in_set = data_flow_env[name_in(self.inst.ID)]
+        new_set = {(v, p) for (v, p) in in_set if v != self.inst.dst}
+        return new_set.union([(self.inst.dst, self.inst.ID)])
+
+    def __str__(self):
+        """
+        A string representation of a reaching-defs equation representing
+        a binary instruction. Eg.:
+            >>> Inst.next_index = 0
+            >>> add = Add('x', 'a', 'b')
+            >>> df = ReachingDefs_Bin_OUT_Eq(add)
+            >>> str(df)
+            'OUT_0: (x, 0) + (IN_0 - (x, _))'
+        """
+        kill_set = f" + ({name_in(self.inst.ID)} - ({self.inst.dst}, _))"
+        gen_set = f"({self.inst.dst}, {self.inst.ID})"
+        return f"{self.name()}: {gen_set}{kill_set}"
+
+
+class ReachingDefs_Bt_OUT_Eq(OUT_Eq):
+    """
+    This concrete class implements the equations that affect OUT facts of the
+    reaching-definitions analysis for branch instructions. These instructions
+    do not affect reaching definitions at all. Therefore, their equations are
+    mostly treated as identity functions.
+    """
+
+    def eval_aux(self, data_flow_env):
+        """
+        Evaluates this equation. Notice that the reaching definition equation
+        for a branch instruction is simply the identity function.
+        OUT[p] = IN[p]
+
+        Example:
+            >>> Inst.next_index = 0
+            >>> i0 = Bt('x')
+            >>> df = ReachingDefs_Bt_OUT_Eq(i0)
+            >>> sorted(df.eval_aux({'IN_0': {('x', 1), ('y', 2)}}))
+            [('x', 1), ('y', 2)]
+        """
+        return data_flow_env[name_in(self.inst.ID)]
+
+    def __str__(self):
+        """
+        A string representation of a reaching-defs equation representing a
+        branch. Eg.:
+            >>> Inst.next_index = 0
+            >>> i = Bt('x')
+            >>> df = ReachingDefs_Bt_OUT_Eq(i)
+            >>> str(df)
+            'OUT_0: IN_0'
+        """
+        kill_set = f"{name_in(self.inst.ID)}"
+        gen_set = f""
+        return f"{self.name()}: {gen_set}{kill_set}"
+
+
+class ReachingDefs_IN_Eq(IN_Eq):
+    """
+    This concrete class implements the meet operation for reaching-definition
+    analysis. The meet operation produces the IN set of a program point. This
+    IN set is the union of the OUT set of the predecessors of this point.
+    """
+
+    def eval_aux(self, data_flow_env):
+        """
+        The evaluation of the meet operation over reaching definitions is the
+        union of the OUT sets of the predecessors of the instruction.
+
+        Example:
+            >>> Inst.next_index = 0
+            >>> i0 = Add('x', 'a', 'b')
+            >>> i1 = Add('x', 'c', 'd')
+            >>> i2 = Add('y', 'x', 'x')
+            >>> i0.add_next(i2)
+            >>> i1.add_next(i2)
+            >>> df = ReachingDefs_IN_Eq(i2)
+            >>> sorted(df.eval_aux({'OUT_0': {('x', 0)}, 'OUT_1': {('x', 1)}}))
+            [('x', 0), ('x', 1)]
+        """
+        solution = set()
+        for inst in self.inst.preds:
+            solution = solution.union(data_flow_env[name_out(inst.ID)])
+        return solution
+
+    def __str__(self):
+        """
+        The name of an IN set is always ID + _IN.
+
+        Example:
+            >>> Inst.next_index = 0
+            >>> i0 = Add('x', 'a', 'b')
+            >>> i1 = Add('x', 'c', 'd')
+            >>> i2 = Add('y', 'x', 'x')
+            >>> i0.add_next(i2)
+            >>> i1.add_next(i2)
+            >>> df = ReachingDefs_IN_Eq(i2)
+            >>> str(df)
+            'IN_2: Union( OUT_0, OUT_1 )'
+        """
+        succs = ", ".join([name_out(pred.ID) for pred in self.inst.preds])
+        return f"{self.name()}: Union( {succs} )"
+
+
+class LivenessAnalysisIN_Eq(IN_Eq):
+    def eval_aux(self, data_flow_env: dict[str, set]) -> None:
+        """
+        Produces the IN set of liveness analysis. The IN set is given by the
+        equation below, considering the instruction `p) v = E`:
+
+        IN[p] = uses(E) + (OUT[p] - {v})
+
+        Example:
+            >>> Inst.next_index = 0
+            >>> i0 = Add('x', 'a', 'b')
+            >>> df = LivenessAnalysisIN_Eq(i0)
+            >>> sorted(df.eval_aux({'OUT_0': {'x'}}))
+            ['a', 'b']
+        """
+        # TODO: implement this method
+
+    def __str__(self):
+        """
+        A string representation of an equation.
+
+        Example:
+            >>> Inst.next_index = 0
+            >>> add = Add('x', 'a', 'b')
+            >>> df = LivenessAnalysisIN_Eq(add)
+            >>> df.__str__()
+            "IN_0: (OUT_0 - {'x'}) + ['a', 'b']"
+        """
+        kill_set = f"({name_out(self.inst.ID)} - {self.inst.definition()})"
+        return f"{self.name()}: {kill_set} + {sorted(self.inst.uses())}"
+
+
+class LivenessAnalysisOUT_Eq(OUT_Eq):
+    def eval_aux(self, data_flow_env: dict[str, set]) -> None:
+        """
+        Computes the join (or meet) operation of the liveness analysis. The
+        join of a point `p` is computed in the following way:
+
+        OUT[p] = union(IN[s]), for s in succ(p)
+
+        Example:
+            >>> Inst.next_index = 0
+            >>> i0 = Add('x', 'c', 'd')
+            >>> i1 = Add('y', 'a', 'a')
+            >>> i2 = Bt('c', i0, i1)
+            >>> df = LivenessAnalysisOUT_Eq(i2)
+            >>> sorted(df.eval_aux({'IN_0': {('c'), ('d')}, 'IN_1': {('a')}}))
+            ['a', 'c', 'd']
+        """
+        # TODO: implement this method
+
+    def __str__(self):
+        """
+        The name of an IN set is always ID + _IN. Eg.:
+            >>> Inst.next_index = 0
+            >>> i0 = Add('x', 'a', 'b')
+            >>> i1 = Add('y', 'x', 'a')
+            >>> i0.add_next(i1)
+            >>> df = LivenessAnalysisOUT_Eq(i0)
+            >>> df.__str__()
+            'OUT_0: Union( IN_1 )'
+        """
+        succs = ""
+        for inst in self.inst.nexts:
+            succs += name_in(inst.ID)
+        return f"{self.name()}: Union( {succs} )"
+
+
+def reaching_defs_constraint_gen(insts):
+    """
+    Builds a list of equations to solve Reaching-Definition Analysis for the
+    given set of instructions.
+
+    Example:
+        >>> Inst.next_index = 0
+        >>> i0 = Add('c', 'a', 'b')
+        >>> i1 = Mul('d', 'c', 'a')
+        >>> i2 = Lth('e', 'c', 'd')
+        >>> i0.add_next(i2)
+        >>> i1.add_next(i2)
+        >>> insts = [i0, i1, i2]
+        >>> sol = [str(eq) for eq in reaching_defs_constraint_gen(insts)]
+        >>> sol[0] + " " + sol[-1]
+        'OUT_0: (c, 0) + (IN_0 - (c, _)) IN_2: Union( OUT_0, OUT_1 )'
+    """
+    in0 = [ReachingDefs_Bin_OUT_Eq(i) for i in insts if isinstance(i, BinOp)]
+    in1 = [ReachingDefs_Bt_OUT_Eq(i) for i in insts if isinstance(i, Bt)]
+    out = [ReachingDefs_IN_Eq(i) for i in insts]
+    return in0 + in1 + out
+
+
+def liveness_constraint_gen(insts: list[Inst]) -> list[DataFlowEq]:
+    """
+    Builds a list of liness-analysis equations extracted from the instructions
+    in the list `insts`
+
+    Example:
+        >>> Inst.next_index = 0
+        >>> i0 = Add('c', 'a', 'b')
+        >>> i1 = Mul('d', 'c', 'a')
+        >>> i0.add_next(i1)
+        >>> insts = [i0, i1]
+        >>> sol = [str(eq) for eq in liveness_constraint_gen(insts)]
+        >>> sol[0] + " " + sol[1]
+        "IN_0: (OUT_0 - {'c'}) + ['a', 'b'] IN_1: (OUT_1 - {'d'}) + ['a', 'c']"
+    """
+    # TODO: implement this method.
+    return []
+
+
+def abstract_interp(equations):
+    """
+    This function iterates on the equations, solving them in the order in which
+    they appear. It returns an environment with the solution to the data-flow
+    analysis.
+
+    Example for liveness analysis:
+        >>> Inst.next_index = 0
+        >>> i0 = Add('c', 'a', 'b')
+        >>> i1 = Mul('d', 'c', 'a')
+        >>> i0.add_next(i1)
+        >>> eqs = liveness_constraint_gen([i0, i1])
+        >>> sol = abstract_interp(eqs)
+        >>> f"IN_0: {sorted(sol['IN_0'])}, OUT_0: {sorted(sol['OUT_0'])}"
+        "IN_0: ['a', 'b'], OUT_0: ['a', 'c']"
+
+    Example for reaching-definition analysis:
+        >>> Inst.next_index = 0
+        >>> i0 = Add('c', 'a', 'b')
+        >>> i1 = Mul('d', 'c', 'a')
+        >>> i0.add_next(i1)
+        >>> eqs = reaching_defs_constraint_gen([i0, i1])
+        >>> sol = abstract_interp(eqs)
+        >>> f"IN_0: {sorted(sol['IN_0'])}, OUT_0: {sorted(sol['OUT_0'])}"
+        "IN_0: [], OUT_0: [('c', 0)]"
+    """
+    from functools import reduce
+
+    env = {eq.name(): set() for eq in equations}
+    changed = True
+    while changed:
+        changed = reduce(lambda acc, eq: eq.eval(env) or acc, equations, False)
+    return env

--- a/SSARegisterAllocation/driver.py
+++ b/SSARegisterAllocation/driver.py
@@ -1,0 +1,48 @@
+from lang import interp, Inst, Add, Mul, Lth, Geq, Bt, Phi, Env
+from graph import new_euclid
+
+prog, env = new_euclid()
+res = interp(prog[0], env)
+res.dump()
+
+
+def ssa_euclid() -> list[Inst]:
+    env = Env({
+        'n0': 16, 'd': 5
+    })
+    i0 = Lth('z', 'n0', 'd')
+    i2 = Mul('negd', 'd', -1)
+    i3 = Phi('result1', 0, 'result2')
+    i4 = Phi('n1', 'n0', 'n2')
+    i5 = Add('result2', 'result1', 1)
+    i6 = Add('n2', 'n1', 'negd')
+    i7 = Geq('l', 'n2', 'd')
+    i9 = Add('remainder', 0, 'n2')
+    i10 = Add('end', 0, 0)
+    i1 = Bt('z', i10)
+    i8 = Bt('l', i3)
+    prog = [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9, i10]
+    for i in range(9):
+        prog[i].add_next(prog[i+1])
+    return prog, env
+
+
+def ssa_fibonacci() -> list[Inst]:
+    env = Env({'iter': 9})
+    i0 = Add('count0', 0, 3)
+    i1 = Add('pred0', 0, 1)
+    i2 = Add('fib0', 0, 1)
+    i3 = Phi('count1', 'count0', 'count2')
+    i4 = Phi('pred1', 'pred0', 'pred2')
+    i5 = Phi('fib1', 'fib0', 'fib2')
+    i6 = Add('aux', 0, 'fib1')
+    i7 = Add('fib2', 'pred1', 'fib1')
+    i8 = Add('pred2', 0, 'aux')
+    i9 = Add('count2', 'count1', 1)
+    i10 = Geq('repeat', 'iter', 'count2')
+    i11 = Bt('repeat', i3)
+    i12 = Add('end', 0, 0)
+    prog = [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9, i10, i11, i12]
+    for i in range(12):
+        prog[i].add_next(prog[i+1])
+    return prog, env

--- a/SSARegisterAllocation/graph.py
+++ b/SSARegisterAllocation/graph.py
@@ -1,0 +1,45 @@
+from lang import Inst, Add, Mul, Lth, Geq, Bt, Phi, Env
+from dataflow import abstract_interp, liveness_constraint_gen
+from collections import defaultdict
+
+
+class InterferenceGraph:
+    def __init__(s, program: list[Inst]):
+        liveness = abstract_interp(liveness_constraint_gen(program))
+        s.graph = defaultdict(lambda: set())
+        s.mcsgraph = defaultdict(lambda: set())
+        s.weights = dict()
+        s.maxweight = 0
+        # build intersection graph
+        for values in liveness.values():
+            for var in values:
+                s.graph[var] |= set(values) - set([var])
+                s.mcsgraph[var] |= set(values) - set([var])
+        for var in s.graph.keys():
+            s.weights[var] = 0
+        # Sort graph vertices (variables) according to weight
+        s.weightedVs = sorted(s.weights.keys(), key=lambda x: s.weights[x])
+
+    def N(s, v: str) -> set[str]:
+        return s.graph[v]
+
+    def size(s):
+        return len(s.mcsgraph)
+
+    def greedy_coloring(s, sequence: list[str]) -> tuple[dict[str, int], int]:
+        # TODO: implement this method
+
+    def maximum_cardinality_search(s):
+        # TODO: implement this method
+
+
+def register_allocation(prog: list[Inst]):
+    """
+    TODO: add descricao de phi aqui
+        >>> prog, env = new_euclid()
+        >>> coloring, num_registers = register_allocation(prog)
+        >>> num_registers
+        5
+    """
+    iGraph = InterferenceGraph(prog)
+    return iGraph.greedy_coloring(iGraph.maximum_cardinality_search())

--- a/SSARegisterAllocation/lang.py
+++ b/SSARegisterAllocation/lang.py
@@ -1,0 +1,785 @@
+"""
+This file contains the implementation of a simple interpreter of low-level
+instructions. The interpreter takes a program, represented as its first
+instruction, plus an environment, which is a stack of bindings. Bindings are
+pairs of variable names and values. New bindings are added to the stack
+whenever new variables are defined. Bindings are never removed from the stack.
+In this way, we can inspect the history of state transformations caused by the
+interpretation of a program. The difference between this file and the files of
+same name in the previous lab is the presence of phi-functions. In other words,
+this new language contains two extra instructions: phi-functions and phi-blocks.
+The latter represents the set of phi-functions that exist at the beginning of
+a basic block.
+
+This file uses doctests all over. To test it, just run python 3 as follows:
+"python3 -m doctest main.py". The program uses syntax that is excluive of
+Python 3. It will not work with standard Python 2.
+"""
+
+from collections import deque
+from abc import ABC, abstractmethod
+from enum import Enum
+
+
+class LangType(Enum):
+    NUM = 1
+    BOOL = 2
+
+
+class Env:
+    """
+    A table that associates variables with values. The environment is
+    implemented as a stack, so that previous bindings of a variable V remain
+    available in the environment if V is overassigned.
+
+    Example:
+        >>> e = Env()
+        >>> e.set("a", 2)
+        >>> e.set("a", 3)
+        >>> e.get("a")
+        3
+
+        >>> e = Env({"b": 5})
+        >>> e.set("a", 2)
+        >>> e.get("a") + e.get("b")
+        7
+    """
+
+    def __init__(s, initial_args={}):
+        s.env = deque()
+        for var, value in initial_args.items():
+            s.env.appendleft((var, value))
+
+    def get(self, var):
+        """
+        Finds the first occurrence of variable 'var' in the environment stack,
+        and returns the value associated with it.
+        """
+        if type(var) in (int, float, bool):
+            return var
+
+        val = next((value for (e_var, value) in self.env if e_var == var), None)
+        if val is not None:
+            return val
+        else:
+            raise LookupError(f"Absent key {var}")
+
+    def get_from_list(self, vars):
+        """
+        Finds the first occurrence of any variable 'vr' in the list 'vars' that
+        has a binding in the environment, and returns the associated value.
+
+        Example:
+            >>> e = Env()
+            >>> e.set("b", 1)
+            >>> e.set("a", 2)
+            >>> e.set("b", 3)
+            >>> e.get_from_list(["b", "a"])
+            3
+
+            >>> e = Env()
+            >>> e.set("b", 1)
+            >>> e.set("a", 2)
+            >>> e.set("b", 3)
+            >>> e.set("a", 4)
+            >>> e.get_from_list(["b", "a"])
+            4
+        """
+        # TODO: Implement this method
+        # ...
+        # This must be kept:
+        for var in vars:
+            if type(var) in (int, float, bool):
+                return var
+        return None
+
+    def set(s, var, value):
+        """
+        This method adds 'var' to the environment, by placing the binding
+        '(var, value)' onto the top of the environment stack.
+        """
+        s.env.appendleft((var, value))
+
+    def dump(s):
+        """
+        Prints the contents of the environment. This method is mostly used for
+        debugging purposes.
+        """
+        for var, value in s.env:
+            print(f"{var}: {value}")
+
+    def to_dict(s):
+        d = dict()
+        for var, value in reversed(s.env):
+            d[var] = value
+        return d
+
+
+class TypeEnvErr(Exception):
+    pass
+
+
+class TypeEnv(Env):
+
+    @classmethod
+    def from_env(cls, env: Env):
+        d = env.to_dict()
+        type_d = dict()
+        for k, v in d.items():
+            t = type(v)
+            if t is int:
+                type_d[k] = LangType.NUM
+            elif t is bool:
+                type_d[k] = LangType.BOOL
+            else:
+                raise TypeEnvErr
+        return TypeEnv(type_d)
+
+    def set(s, var, value: LangType):
+        """
+        This method wraps the inherited set(var, value) method, making
+        sure only LangType values are accepted.
+        """
+        if type(value) is not LangType:
+            raise TypeEnvErr
+        else:
+            s.env.appendleft((var, value))
+
+
+class Inst(ABC):
+    """
+    The representation of instructions. All that an instruction has, that is
+    common among all the instructions, is the next_inst attribute. This
+    attribute determines the next instruction that will be fetched after this
+    instruction runs. Also, every instruction has an index, which is always
+    different. The index is incremented whenever a new instruction is created.
+    """
+
+    next_index = 0
+
+    def __init__(self):
+        self.nexts = []
+        self.preds = []
+        self.ID = Inst.next_index
+        Inst.next_index += 1
+
+    def add_next(self, next_inst):
+        self.nexts.append(next_inst)
+        next_inst.preds.append(self)
+
+    @classmethod
+    @abstractmethod
+    def definition(self):
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def uses(self):
+        raise NotImplementedError
+
+    def get_next(self):
+        if len(self.nexts) > 0:
+            return self.nexts[0]
+        else:
+            return None
+
+
+class InstTypeErr(Exception):
+    def __init__(s, inst: Inst, expected: LangType, found: LangType):
+        s.inst = inst
+        s.expected = expected
+        s.found = found
+        message = f'Type error in instruction {inst.ID}\n' \
+                  f'Expected: {expected}, found: {found}'
+        super().__init__(message)
+
+
+class Phi(Inst):
+    """
+    A Phi-Function is an abstract notation used to facilitate the implementation
+    of static analyses. They were not really conceived to have a dynamic
+    semantics. Nevertheless, we can still interpret programs containing
+    phi-functions. A possible semantics of 'a = phi(a0, a1, a2)' is to
+    recover, from the environment, the first binding of either a0, a1 or a2.
+    If our program were in the so-called "Conventional-SSA Form", this
+    semantics would be perfect. But our program is not in such a format, and
+    we might have issues with swaps, for instance. That's why we shall use
+    phi-blocks to implement phi-functions. All the same, you can still write
+    programs using phi-functions without using phi-blocks, as long as variables
+    that are related by phi-functions do not have overlapping live ranges.
+
+    Example:
+        >>> a = Phi("a", "b0", "b1", "b2")
+        >>> e = Env()
+        >>> e.set("b0", 1)
+        >>> e.set("b1", 3)
+        >>> a.eval(e)
+        >>> e.get("a")
+        3
+
+        >>> a = Phi("a", "b0", "b1")
+        >>> e = Env()
+        >>> e.set("b1", 3)
+        >>> e.set("b0", 1)
+        >>> a.eval(e)
+        >>> e.get("a")
+        1
+    """
+
+    def __init__(s, dst, *args):
+        s.dst = dst
+        s.args = list(args)
+        super().__init__()
+
+    def definition(s):
+        return set([s.dst])
+
+    def uses(s):
+        use_set = set()
+        for arg in s.args:
+            if type(arg) not in (int, float, bool):
+                use_set.add(arg)
+        return use_set
+
+    def eval(s, env):
+        """
+        If the program were in Conventional-SSA form, then we could correctly
+        implement the semantics of phi-functions simply retrieving the first
+        occurrence of each variable in the list of uses. However, notice what
+        would happen with swaps:
+
+        >>> a0 = Phi("a0", "a1", "a0")
+        >>> a1 = Phi("a1", "a0", "a1")
+        >>> e = Env()
+        >>> e.set("a0", 1)
+        >>> e.set("a1", 3)
+        >>> a0.eval(e)
+        >>> a1.eval(e)
+        >>> e.get("a0") - e.get("a1")
+        0
+
+        In the example above, we would like to evaluate the two phi-functions in
+        parallel, e.g.: (a0, a1) = (a0:1, a1:3). In this way, after the
+        evaluation, we would like to have a0 == 3 and a1 == 1. However, there is
+        no way we can do it: our phi-functions are evaluated once at a time! The
+        problem is that variables a0 and a1 are defined by different
+        phi-functions, but they have overlapping live ranges. So, this
+        program is not in conventional SSA-form (as per Definition 1 in the
+        paper 'SSA Elimination after Register Allocation' - 2009).
+        """
+        env.set(s.dst, env.get_from_list(s.args))
+
+    def type_eval(s, type_env):
+        """
+        Assume that our language does not allow for type changes in variables.
+        Thus, all arguments in a Phi-Function must belong to the same type.
+        Example:
+
+            >>> Inst.next_index = 0
+            >>> i0 = Phi("a", "b0", "b1")
+            >>> e = TypeEnv()
+            >>> e.set("b0", LangType.NUM)
+            >>> e.set("b1", LangType.BOOL)
+            >>> i0.type_eval(e)
+            Traceback (most recent call last):
+             ...
+            lang.InstTypeErr: Type error in instruction 0
+            Expected: LangType.NUM, found: LangType.BOOL
+        """
+        # TODO: implement this method
+
+    def __str__(self):
+        use_list = ", ".join(self.uses())
+        inst_s = f"{self.ID}: {self.dst} = phi[{use_list}]"
+        pred_s = f"\n  P: {', '.join([str(inst.ID) for inst in self.preds])}"
+        next_s = f"\n  N: {self.nexts[0].ID if len(self.nexts) > 0 else ''}"
+        return inst_s + pred_s + next_s
+
+
+class ReadNum(Inst):
+    """
+    The ReadNum instruction introduces non-constant values to the program.
+    This blocking instruction requests a numerical input from the user.
+    """
+    def __init__(s, dst):
+        s.dst = dst
+        super().__init__()
+
+    def definition(s):
+        return {s.dst}
+
+    def uses(s):
+        return set()
+
+    def eval(s, env):
+        """
+        For simplicity, ReadNum fails with any value other than ints
+        """
+        input_value = input(f'value for {s.dst}: ')
+        if type(input_value) is not int:
+            raise InstTypeErr(s, int, type(input_value))
+        env.set(s.dst, int(input_value))
+
+    def type_eval(s, type_env):
+        type_env.set(s.dst, LangType.NUM)
+
+    def __str__(self):
+        inst_s = f"{self.ID}: {self.dst} = INPUT"
+        pred_s = f"\n  P: {', '.join([str(inst.ID) for inst in self.preds])}"
+        next_s = f"\n  N: {self.nexts[0].ID if len(self.nexts) > 0 else ''}"
+        return inst_s + pred_s + next_s
+
+
+class ReadBool(Inst):
+    """
+    The ReadNum instruction introduces non-constant values to the program.
+    This blocking instruction requests a numerical input from the user.
+    """
+    def __init__(s, dst):
+        s.dst = dst
+        super().__init__()
+
+    def definition(s):
+        return {s.dst}
+
+    def uses(s):
+        return set()
+
+    def eval(s, env):
+        """
+        For simplicity, ReadBool fails with any value other than bool
+        """
+        input_value = input(f'value for {s.dst}: ')
+        if type(input_value) is not bool:
+            raise InstTypeErr(s, bool, type(input_value))
+        env.set(s.dst, int(input_value))
+
+    def type_eval(s, type_env):
+        type_env.set(s.dst, LangType.BOOL)
+
+    def __str__(self):
+        inst_s = f"{self.ID}: {self.dst} = INPUT"
+        pred_s = f"\n  P: {', '.join([str(inst.ID) for inst in self.preds])}"
+        next_s = f"\n  N: {self.nexts[0].ID if len(self.nexts) > 0 else ''}"
+        return inst_s + pred_s + next_s
+
+
+class PhiBlock(Inst):
+    """
+    PhiBlocks implement a correct semantics for groups of phi-functions. A
+    phi-block groups a number of phi-functions as a matrix. Once a phi-block
+    is evaluated, all the values in a given column of this matrix are read and
+    saved, and then the definitions are updated --- all in parallel. To see a
+    more detailed explanation of this semantics, please, refer to Section 3 of
+    the paper 'SSA Elimination after Register Allocation'. In particular, take
+    a look into Figure 1 of that paper.
+
+    Example:
+        >>> a0 = Phi("a0", "a0", "a1")
+        >>> a1 = Phi("a1", "a1", "a0")
+        >>> aa = PhiBlock([a0, a1], [10, 31])
+        >>> e = Env()
+        >>> e.set("a0", 1)
+        >>> e.set("a1", 3)
+        >>> aa.eval(e, 10)
+        >>> e.get("a0") - e.get("a1")
+        -2
+
+        >>> a0 = Phi("a0", "a0", "a1")
+        >>> a1 = Phi("a1", "a1", "a0")
+        >>> aa = PhiBlock([a0, a1], [10, 31])
+        >>> e = Env()
+        >>> e.set("a0", 1)
+        >>> e.set("a1", 3)
+        >>> aa.eval(e, 31)
+        >>> e.get("a0") - e.get("a1")
+        2
+    """
+
+    def __init__(self, phis, selector_IDs):
+        """
+        A phi-block represents an M*N matrix, where each one of the M lines is
+        a phi-function, and each phi-function reads from N different parameters.
+        Each one of these N columns is associated with a 'selector', which is
+        the ID of the instruction that leads to that parallel assignment.
+
+        Examples:
+            >>> a0 = Phi("a0", ["a0", "a1"])
+            >>> a1 = Phi("a1", ["a1", "a0"])
+            >>> aa = PhiBlock([a0, a1], [10, 31])
+            >>> sorted(aa.selectors.items())
+            [(10, 0), (31, 1)]
+
+            >>> a0 = Phi("a0", ["a0", "a1"])
+            >>> a1 = Phi("a1", ["a1", "a0"])
+            >>> aa = PhiBlock([a0, a1], [10, 31])
+            >>> sorted([phi.definition().pop() for phi in aa.phis])
+            ['a0', 'a1']
+        """
+        self.phis = phis
+        # TODO: implement the rest of this method
+        # here...
+        #########################################
+        super().__init__()
+
+    def definition(self):
+        """
+        We consider that a phi-block defines multiple variables. These are the
+        variables assignment by the phi-functions that the phi-block contains.
+
+        Example:
+            >>> a0 = Phi("a0", ["a0", "a1"])
+            >>> a1 = Phi("a1", ["a1", "a0"])
+            >>> aa = PhiBlock([a0, a1], [10, 31])
+            >>> sorted(aa.definition())
+            ['a0', 'a1']
+        """
+        return [phi.definition().pop() for phi in self.phis]
+
+    def uses(self):
+        """
+        The uses of a phi-block are all the variables used by the phi-functions
+        that it contains. Notice that we don't need this method for anything; it
+        is here rather to help understand the structure of phi-blocks.
+
+        Example:
+            >>> a0 = Phi("a0", "a0", "x")
+            >>> a1 = Phi("a1", "y", "a0")
+            >>> aa = PhiBlock([a0, a1], [10, 31])
+            >>> sorted(aa.uses())
+            ['a0', 'a0', 'x', 'y']
+        """
+        return sum([phi.uses() for phi in self.phis], [])
+
+    def eval(self, env: Env, PC: int):
+        # TODO: Read all the definitions
+        # TODO: Assign all the uses:
+
+    def type_eval(s, type_env):
+        """
+        For type checking, it is sufficient to assure that all Phi arguments
+        belong to the same type.
+
+        Example:
+            >>> Inst.next_index = 0
+            >>> a0 = Phi("a0", "a0", "a1")
+            >>> a1 = Phi("a1", "a1", "a0")
+            >>> aa = PhiBlock([a0, a1], [10, 31])
+            >>> e = TypeEnv({"a0": LangType.NUM, "a1": LangType.BOOL})
+            >>> aa.type_eval(e)
+            Traceback (most recent call last):
+             ...
+            lang.InstTypeErr: Type error in instruction 0
+            Expected: LangType.NUM, found: LangType.BOOL
+        """
+        # TODO: implement this method
+
+    def __str__(self):
+        block_str = "\n".join([str(phi) for phi in self.phis])
+        return f"PHI_BLOCK [\n{block_str}\n]"
+
+
+class BinOp(Inst):
+    """
+    The general class of binary instructions. These instructions define a
+    value, and use two values. As such, it contains a routine to extract the
+    defined value, and the list of used values.
+    """
+
+    def __init__(s, dst, src0, src1):
+        s.dst = dst
+        s.src0 = src0
+        s.src1 = src1
+        super().__init__()
+
+    @classmethod
+    @abstractmethod
+    def get_opcode(self):
+        raise NotImplementedError
+
+    def definition(s):
+        return set([s.dst])
+
+    def uses(s):
+        use_set = set()
+        for src in [s.src0, s.src1]:
+            if type(src) not in (int, float, bool):
+                use_set.add(src)
+        return use_set
+
+    def __str__(self):
+        op = self.get_opcode()
+        inst_s = f"{self.ID}: {self.dst} = {self.src0}{op}{self.src1}"
+        pred_s = f"\n  P: {', '.join([str(inst.ID) for inst in self.preds])}"
+        next_s = f"\n  N: {self.nexts[0].ID if len(self.nexts) > 0 else ''}"
+        return inst_s + pred_s + next_s
+
+
+class Add(BinOp):
+    """
+    Example:
+        >>> a = Add("a", "b0", "b1")
+        >>> e = Env({"b0":2, "b1":3})
+        >>> a.eval(e)
+        >>> e.get("a")
+        5
+
+        >>> a = Add("a", "b0", "b1")
+        >>> a.get_next() == None
+        True
+    """
+
+    def eval(self, env):
+        env.set(self.dst, env.get(self.src0) + env.get(self.src1))
+
+    def type_eval(s, type_env):
+        """
+        Additions will always require and result in a numerical value:
+            >>> Inst.next_index = 0
+            >>> a = Add("a", "b0", "b1")
+            >>> e = TypeEnv({"b0": LangType.NUM, "b1": LangType.BOOL})
+            >>> a.type_eval(e)
+            Traceback (most recent call last):
+             ...
+            lang.InstTypeErr: Type error in instruction 0
+            Expected: LangType.NUM, found: LangType.BOOL
+
+            >>> a = Add("a", "b0", "b1")
+            >>> e = TypeEnv({"b0": LangType.NUM, "b1": LangType.NUM})
+            >>> a.type_eval(e)
+            >>> print(e.get("a"))
+            LangType.NUM
+        """
+        # TODO: implement this method
+
+    def get_opcode(self):
+        return "+"
+
+
+class Mul(BinOp):
+    """
+    Example:
+        >>> a = Mul("a", "b0", "b1")
+        >>> e = Env({"b0":2, "b1":3})
+        >>> a.eval(e)
+        >>> e.get("a")
+        6
+    """
+
+    def eval(s, env):
+        env.set(s.dst, env.get(s.src0) * env.get(s.src1))
+
+    def type_eval(s, type_env):
+        """
+        Multiplications will always require and result in a numerical value:
+            >>> Inst.next_index = 0
+            >>> a = Mul("a", "b0", "b1")
+            >>> e = TypeEnv({"b0": LangType.NUM, "b1": LangType.BOOL})
+            >>> a.type_eval(e)
+            Traceback (most recent call last):
+             ...
+            lang.InstTypeErr: Type error in instruction 0
+            Expected: LangType.NUM, found: LangType.BOOL
+
+            >>> a = Mul("a", "b0", "b1")
+            >>> e = TypeEnv({"b0": LangType.NUM, "b1": LangType.NUM})
+            >>> a.type_eval(e)
+            >>> print(e.get("a"))
+            LangType.NUM
+        """
+        # TODO: implement this method
+
+    def get_opcode(self):
+        return "*"
+
+
+class Lth(BinOp):
+    """
+    Example:
+        >>> a = Lth("a", "b0", "b1")
+        >>> e = Env({"b0":2, "b1":3})
+        >>> a.eval(e)
+        >>> e.get("a")
+        True
+    """
+
+    def eval(s, env):
+        env.set(s.dst, env.get(s.src0) < env.get(s.src1))
+
+    def type_eval(s, type_env):
+        """
+        Comparisons will always require numerical values and output booleans:
+            >>> Inst.next_index = 0
+            >>> a = Lth("a", "b0", "b1")
+            >>> e = TypeEnv({"b0": LangType.NUM, "b1": LangType.BOOL})
+            >>> a.type_eval(e)
+            Traceback (most recent call last):
+             ...
+            lang.InstTypeErr: Type error in instruction 0
+            Expected: LangType.NUM, found: LangType.BOOL
+
+            >>> a = Lth("a", "b0", "b1")
+            >>> e = TypeEnv({"b0": LangType.NUM, "b1": LangType.NUM})
+            >>> a.type_eval(e)
+            >>> print(e.get("a"))
+            LangType.BOOL
+        """
+        # TODO: implement this method
+
+    def get_opcode(self):
+        return "<"
+
+
+class Geq(BinOp):
+    """
+    Example:
+        >>> a = Geq("a", "b0", "b1")
+        >>> e = Env({"b0":2, "b1":3})
+        >>> a.eval(e)
+        >>> e.get("a")
+        False
+    """
+
+    def eval(s, env):
+        env.set(s.dst, env.get(s.src0) >= env.get(s.src1))
+
+    def type_eval(s, type_env):
+        """
+        Comparisons will always require numerical values and output booleans:
+            >>> Inst.next_index = 0
+            >>> a = Geq("a", "b0", "b1")
+            >>> e = TypeEnv({"b0": LangType.NUM, "b1": LangType.BOOL})
+            >>> a.type_eval(e)
+            Traceback (most recent call last):
+             ...
+            lang.InstTypeErr: Type error in instruction 0
+            Expected: LangType.NUM, found: LangType.BOOL
+
+            >>> a = Geq("a", "b0", "b1")
+            >>> e = TypeEnv({"b0": LangType.NUM, "b1": LangType.NUM})
+            >>> a.type_eval(e)
+            >>> print(e.get("a"))
+            LangType.BOOL
+        """
+        # TODO: implement this method
+
+    def get_opcode(self):
+        return ">="
+
+
+class Bt(Inst):
+    """
+    This is a Branch-If-True instruction, which diverts the control flow to the
+    'true_dst' if the predicate 'pred' is true, and to the 'false_dst'
+    otherwise.
+
+    Example:
+        >>> e = Env({"t": True, "x": 0})
+        >>> a = Add("x", "x", "x")
+        >>> m = Mul("x", "x", "x")
+        >>> b = Bt("t", a, m)
+        >>> b.eval(e)
+        >>> b.get_next() == a
+        True
+    """
+
+    def __init__(s, cond, true_dst=None, false_dst=None):
+        super().__init__()
+        s.cond = cond
+        s.nexts = [true_dst, false_dst]
+        s.next_iter = 1  # By default, perform no jump
+        if true_dst != None:
+            true_dst.preds.append(s)
+        if false_dst != None:
+            false_dst.preds.append(s)
+
+    def definition(s):
+        return set()
+
+    def uses(s):
+        return set([s.cond])
+
+    def add_true_next(s, true_dst):
+        s.nexts[0] = true_dst
+        true_dst.preds.append(s)
+
+    def add_next(s, false_dst):
+        s.nexts[1] = false_dst
+        false_dst.preds.append(s)
+
+    def eval(s, env):
+        """
+        The evaluation of the condition sets the next_iter to the instruction.
+        This value determines which successor instruction is to be evaluated.
+        Any values greater than 0 are evaluated as True, while 0 corresponds to
+        False.
+        """
+        if env.get(s.cond):
+            s.next_iter = 0
+        else:
+            s.next_iter = 1
+
+    def type_eval(s, type_env):
+        """
+        Branch instructions require boolean conditions:
+            >>> Inst.next_index = 0
+            >>> a = Add("x", "x", "x")
+            >>> m = Mul("x", "x", "x")
+            >>> b = Bt("t", a, m)
+            >>> e = TypeEnv({"t": LangType.NUM})
+            >>> b.type_eval(e)
+            Traceback (most recent call last):
+             ...
+            lang.InstTypeErr: Type error in instruction 2
+            Expected: LangType.BOOL, found: LangType.NUM
+        """
+        # TODO: implement this method
+
+    def get_next(s):
+        return s.nexts[s.next_iter]
+
+    def __str__(self):
+        inst_s = f"{self.ID}: bt {self.cond}"
+        pred_s = f"\n  P: {', '.join([str(inst.ID) for inst in self.preds])}"
+        next_s = f"\n  NT:{self.nexts[0].ID} NF:{self.nexts[1].ID}"
+        return inst_s + pred_s + next_s
+
+
+def interp(instruction: Inst, environment: Env, PC=0):
+    """
+    This function evaluates a program until there is no more instructions to
+    evaluate. Notice that, in contrast to the previous labs, the interpreter
+    now receives three arguments. The third argument is necessary to implement
+    the correct semantics of phi-functions using phi-blocks. This argument can
+    be used to select the correct parallel copy that a PhiBlock implements.
+
+    Parameters:
+    -----------
+        instruction: the instruction that will be interpreted
+        environment: the list that associates variable names with their values
+        PC: the identifier of the last instruction that was interpreted.
+
+    Example:
+        >>> env = Env({"m": 3, "n": 2, "zero": 0})
+        >>> m_min = Add("answer", "m", "zero")
+        >>> n_min = Add("answer", "n", "zero")
+        >>> p = Lth("p", "n", "m")
+        >>> b = Bt("p", n_min, m_min)
+        >>> p.add_next(b)
+        >>> interp(p, env).get("answer")
+        2
+    """
+    if instruction:
+        if isinstance(instruction, PhiBlock):
+            instruction.eval(environment, PC)
+        else:
+            instruction.eval(environment)
+        return interp(instruction.get_next(), environment, instruction.ID)
+    else:
+        return environment
+
+
+def type_check(instruction: Inst,
+               type_env: TypeEnv,
+               phi_queue: list[Inst] = []):
+    # TODO: implement type checking


### PR DESCRIPTION
This activity requires students to implement the Maximum Cardinality Seach algorithm, as well as greedy coloring, which is applied on the interference graph of SSA-form programs. The theme is Register Allocation, and the technique used is inspired by the paper "Register Allocation via Coloring of Chordal Graphs".

For the moment, the lab ends at the first step of the algorithm - that is, it produces an initial coloring. It is possible to enhance it by adding spilling (i think coalescing would make it too complex). I have been a bit troubled with the dependencies, namely **lang.py**. In order simplify the register allocation, I have changed the **Env.get** and **Env.get_from_list** methods to allow numerals directly in instructions. This requires a slightly different implementation of the **Inst.uses** method to avoid listing numerals in liveness analysis.

I am creating the Pull Request for your analysis. However, we may profit from further deciding what to do with **lang.py** before merging....