### PR TITLE
fix: clean up docstrings, rename function for consistency, remove debug prints

### DIFF
--- a/ConstantPropagation/Answers/parser.py
+++ b/ConstantPropagation/Answers/parser.py
@@ -10,7 +10,7 @@ As an example, the program below sums up the numbers a, b and c:
 
     {"a": 1, "b": 3, "c": 5}
     x = add a b
-    l2 = x = add x c
+    x = add x c
 """
 
 from lang import Env, Inst, Add, Mul, Lth, Geq, Read, Phi, Bt, interp

--- a/ConstantPropagation/parser.py
+++ b/ConstantPropagation/parser.py
@@ -12,7 +12,7 @@ As an example, the program below sums up the numbers a, b and c:
 
     {"a": 1, "b": 3, "c": 5}
     x = add a b
-    l2 = x = add x c
+    x = add x c
 """
 
 

--- a/Parsing/README.md
+++ b/Parsing/README.md
@@ -26,7 +26,7 @@ As an example, the program below sums up the numbers a, b and c:
 ```
 {"a": 1, "b": 3, "c": 5}
 x = add a b
-l2 = x = add x c
+x = add x c
 ```
 
 To solve this lab, you will have to implement the function `file2cfg_and_env`. 

--- a/Parsing/todo.py
+++ b/Parsing/todo.py
@@ -10,7 +10,7 @@ As an example, the program below sums up the numbers a, b and c:
 
     {"a": 1, "b": 3, "c": 5}
     x = add a b
-    l2 = x = add x c
+    x = add x c
 """
 
 from lang import Env, Inst

--- a/PhiFunctions/lang.py
+++ b/PhiFunctions/lang.py
@@ -500,9 +500,6 @@ def interp(instruction: Inst, environment: Env, PC=0):
         2
     """
     if instruction:
-        print("----------------------------------------------------------")
-        print(instruction)
-        environment.dump()
         if isinstance(instruction, PhiBlock):
             # TODO: implement this part:
             pass

--- a/TypeChecking/parser.py
+++ b/TypeChecking/parser.py
@@ -10,7 +10,7 @@ As an example, the program below sums up the numbers a, b and c:
 
     {"a": 1, "b": 3, "c": 5}
     x = add a b
-    l2 = x = add x c
+    x = add x c
 """
 
 from lang import Env, Inst, Add, Mul, Lth, Geq, ReadNum, ReadBool, Phi, Bt

--- a/Worklist/dataflow.py
+++ b/Worklist/dataflow.py
@@ -353,7 +353,7 @@ def build_dependence_graph(equations) -> dict[str, list[DataFlowEq]]:
     return dep_graph
 
 
-def abstract_interp_worklist(equations) -> tuple[Env, int]:
+def abstract_interp(equations) -> tuple[Env, int]:
     """
     This function solves the system of equations using a worklist. Once an
     equation E is evaluated, and the evaluation changes the environment, only
@@ -365,7 +365,7 @@ def abstract_interp_worklist(equations) -> tuple[Env, int]:
         >>> i1 = Mul('d', 'c', 'a')
         >>> i0.add_next(i1)
         >>> eqs = reaching_defs_constraint_gen([i0, i1])
-        >>> (sol, num_evals) = abstract_interp_worklist(eqs)
+        >>> (sol, num_evals) = abstract_interp(eqs)
         >>> f"OUT_0: {sorted(sol['OUT_0'])}"
         "OUT_0: [('c', 0)]"
     """

--- a/Worklist/driver.py
+++ b/Worklist/driver.py
@@ -13,7 +13,7 @@ def chaotic_solver(program):
 
 def worklist_solver(program):
     equations = dataflow.reaching_defs_constraint_gen(program)
-    return dataflow.abstract_interp_worklist(equations)
+    return dataflow.abstract_interp(equations)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**First commit:** fixes leftover copy/paste artifacts in some docstrings.
**Second commit:** renames a function and updates its calls to match the naming pattern used in other assignments.
**Third commit:** removes leftover debugging prints that were breaking the doctests.